### PR TITLE
Skylab: remote GPU execution, distributed training, and project rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ dev/
 
 # Results file
 results.tsv
+
+# Remote execution state
+remote.toml
+.remote_state
+run.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Make python3.10 the default python3
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
 
-# Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+# Install uv (pinned version for reproducibility)
+ARG UV_VERSION=0.7.12
+RUN curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
 ENV PATH="/root/.local/bin:$PATH"
 
 WORKDIR /workspace/autoresearch
@@ -21,7 +22,7 @@ WORKDIR /workspace/autoresearch
 COPY pyproject.toml uv.lock .python-version ./
 
 # Install all dependencies (expensive — cached unless deps change)
-RUN uv sync
+RUN uv sync --frozen
 
 # Copy project source
 COPY prepare.py train.py ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM nvidia/cuda:12.8.0-devel-ubuntu22.04
+
+# Avoid interactive prompts during apt-get
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3.10 python3.10-venv python3.10-dev curl git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Make python3.10 the default python3
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
+
+# Install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
+
+WORKDIR /workspace/autoresearch
+
+# Copy dependency files first (layer caching — only re-install when deps change)
+COPY pyproject.toml uv.lock .python-version ./
+
+# Install all dependencies (expensive — cached unless deps change)
+RUN uv sync
+
+# Copy project source
+COPY prepare.py train.py ./
+
+# Data is mounted at runtime, not baked into the image.
+# Mount your data volume at /root/.cache/autoresearch/

--- a/README.md
+++ b/README.md
@@ -134,13 +134,6 @@ remote.toml     — remote host configuration (gitignored)
 Dockerfile      — reproducible CUDA environment
 ```
 
-## Notable forks
-
-- [miolini/autoresearch-macos](https://github.com/miolini/autoresearch-macos) (MacOS)
-- [trevin-creator/autoresearch-mlx](https://github.com/trevin-creator/autoresearch-mlx) (MacOS)
-- [jsegov/autoresearch-win-rtx](https://github.com/jsegov/autoresearch-win-rtx) (Windows)
-- [andyluo7/autoresearch](https://github.com/andyluo7/autoresearch) (AMD)
-
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -2,95 +2,55 @@
 
 ![teaser](progress.png)
 
-*One day, frontier AI research used to be done by meat computers in between eating, sleeping, having other fun, and synchronizing once in a while using sound wave interconnect in the ritual of "group meeting". That era is long gone. Research is now entirely the domain of autonomous swarms of AI agents running across compute cluster megastructures in the skies. The agents claim that we are now in the 10,205th generation of the code base, in any case no one could tell if that's right or wrong as the "code" is now a self-modifying binary that has grown beyond human comprehension. This repo is the story of how it all began. -@karpathy, March 2026*.
+Autonomous LLM training research — give an AI agent a real training setup and let it experiment overnight. It modifies the code, trains for 5 minutes, checks if the result improved, keeps or discards, and repeats. You wake up to a log of experiments and a better model.
 
-The idea: give an AI agent a small but real LLM training setup and let it experiment autonomously overnight. It modifies the code, trains for 5 minutes, checks if the result improved, keeps or discards, and repeats. You wake up in the morning to a log of experiments and (hopefully) a better model. The training code here is a simplified single-GPU implementation of [nanochat](https://github.com/karpathy/nanochat). The core idea is that you're not touching any of the Python files like you normally would as a researcher. Instead, you are programming the `program.md` Markdown files that provide context to the AI agents and set up your autonomous research org. The default `program.md` in this repo is intentionally kept as a bare bones baseline, though it's obvious how one would iterate on it over time to find the "research org code" that achieves the fastest research progress, how you'd add more agents to the mix, etc. A bit more context on this project is here in this [tweet](https://x.com/karpathy/status/2029701092347630069) and [this tweet](https://x.com/karpathy/status/2031135152349524125).
+Based on [@karpathy's autoresearch](https://github.com/karpathy/autoresearch), extended with remote GPU execution and multi-GPU distributed training support.
 
 ## How it works
 
-The repo is deliberately kept small and only really has three files that matter:
+Three files matter:
 
-- **`prepare.py`** — fixed constants, one-time data prep (downloads training data, trains a BPE tokenizer), and runtime utilities (dataloader, evaluation). Not modified.
-- **`train.py`** — the single file the agent edits. Contains the full GPT model, optimizer (Muon + AdamW), and training loop. Everything is fair game: architecture, hyperparameters, optimizer, batch size, etc. **This file is edited and iterated on by the agent**.
-- **`program.md`** — baseline instructions for one agent. Point your agent here and let it go. **This file is edited and iterated on by the human**.
+- **`prepare.py`** — fixed constants, data prep, tokenizer, dataloader, evaluation. Not modified.
+- **`train.py`** — model, optimizer, training loop. **The agent edits this file**.
+- **`program.md`** — agent instructions. **The human edits this file**.
 
-By design, training runs for a **fixed 5-minute time budget** (wall clock, excluding startup/compilation), regardless of the details of your compute. The metric is **val_bpb** (validation bits per byte) — lower is better, and vocab-size-independent so architectural changes are fairly compared.
-
-If you are new to neural networks, this ["Dummy's Guide"](https://x.com/hooeem/status/2030720614752039185) looks pretty good for a lot more context.
+Training runs for a **fixed 5-minute time budget**. The metric is **val_bpb** (validation bits per byte) — lower is better, vocab-size-independent so architectural changes are fairly compared. ~12 experiments/hour, ~100 overnight.
 
 ## Quick start
 
-**Requirements:** A single NVIDIA GPU (tested on H100), Python 3.10+, [uv](https://docs.astral.sh/uv/).
+**Requirements:** NVIDIA GPU (tested on H100), Python 3.10+, [uv](https://docs.astral.sh/uv/).
 
 ```bash
-
-# 1. Install uv project manager (if you don't already have it)
+# Install uv (if needed)
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# 2. Install dependencies
+# Install dependencies
 uv sync
 
-# 3. Download data and train tokenizer (one-time, ~2 min)
+# Download data and train tokenizer (one-time, ~2 min)
 uv run prepare.py
 
-# 4. Manually run a single training experiment (~5 min)
+# Run a single training experiment (~5 min)
 uv run train.py
 ```
 
-If the above commands all work ok, your setup is working and you can go into autonomous research mode.
-
 ## Running the agent
 
-Simply spin up your Claude/Codex or whatever you want in this repo (and disable all permissions), then you can prompt something like:
+Point your agent (Claude, Codex, etc.) at this repo and prompt:
 
 ```
 Hi have a look at program.md and let's kick off a new experiment! let's do the setup first.
 ```
 
-The `program.md` file is essentially a super lightweight "skill".
+The agent reads `program.md`, sets up a branch, and loops: modify `train.py` → train → measure → keep or discard.
 
-## Project structure
+## Remote execution
 
-```
-prepare.py      — constants, data prep + runtime utilities (do not modify)
-train.py        — model, optimizer, training loop (agent modifies this)
-program.md      — agent instructions
-pyproject.toml  — dependencies
-```
-
-## Design choices
-
-- **Single file to modify.** The agent only touches `train.py`. This keeps the scope manageable and diffs reviewable.
-- **Fixed time budget.** Training always runs for exactly 5 minutes, regardless of your specific platform. This means you can expect approx 12 experiments/hour and approx 100 experiments while you sleep. There are two upsides of this design decision. First, this makes experiments directly comparable regardless of what the agent changes (model size, batch size, architecture, etc). Second, this means that autoresearch will find the most optimal model for your platform in that time budget. The downside is that your runs (and results) become not comparable to other people running on other compute platforms.
-- **Self-contained.** No external dependencies beyond PyTorch and a few small packages. One file, one metric. Multi-GPU is supported via `torchrun` but single-GPU remains the default.
-
-## Platform support
-
-This code currently requires that you have a single NVIDIA GPU. In principle it is quite possible to support CPU, MPS and other platforms but this would also bloat the code. I'm not 100% sure that I want to take this on personally right now. People can reference (or have their agents reference) the full/parent nanochat repository that has wider platform support and shows the various solutions (e.g. a Flash Attention 3 kernels fallback implementation, generic device support, autodetection, etc.), feel free to create forks or discussions for other platforms and I'm happy to link to them here in the README in some new notable forks section or etc.
-
-Seeing as there seems to be a lot of interest in tinkering with autoresearch on much smaller compute platforms than an H100, a few extra words. If you're going to try running autoresearch on smaller computers (Macbooks etc.), I'd recommend one of the forks below. On top of this, here are some recommendations for how to tune the defaults for much smaller models for aspiring forks:
-
-1. To get half-decent results I'd use a dataset with a lot less entropy, e.g. this [TinyStories dataset](https://huggingface.co/datasets/karpathy/tinystories-gpt4-clean). These are GPT-4 generated short stories. Because the data is a lot narrower in scope, you will see reasonable results with a lot smaller models (if you try to sample from them after training).
-2. You might experiment with decreasing `vocab_size`, e.g. from 8192 down to 4096, 2048, 1024, or even - simply byte-level tokenizer with 256 possibly bytes after utf-8 encoding.
-3. In `prepare.py`, you'll want to lower `MAX_SEQ_LEN` a lot, depending on the computer even down to 256 etc. As you lower `MAX_SEQ_LEN`, you may want to experiment with increasing `DEVICE_BATCH_SIZE` in `train.py` slightly to compensate. The number of tokens per fwd/bwd pass is the product of these two.
-4. Also in `prepare.py`, you'll want to decrease `EVAL_TOKENS` so that your validation loss is evaluated on a lot less data.
-5. In `train.py`, the primary single knob that controls model complexity is the `DEPTH` (default 8, here). A lot of variables are just functions of this, so e.g. lower it down to e.g. 4.
-6. You'll want to most likely use `WINDOW_PATTERN` of just "L", because "SSSL" uses alternating banded attention pattern that may be very inefficient for you. Try it.
-7. You'll want to lower `TOTAL_BATCH_SIZE` a lot, but keep it powers of 2, e.g. down to `2**14` (~16K) or so even, hard to tell.
-
-I think these would be the reasonable hyperparameters to play with. Ask your favorite coding agent for help and copy paste them this guide, as well as the full source code.
-
-## Remote & multi-GPU execution
-
-While the default setup targets a single local GPU, the repo also supports running experiments on remote GPU machines and scaling across multiple GPUs.
-
-### Remote execution
-
-The `remote_run.sh` script is a drop-in replacement for `uv run train.py` that transparently syncs your code to a remote GPU machine, runs training, and streams results back:
+Run experiments on a remote GPU machine without changing any training code. `remote_run.sh` syncs your code via SSH, runs training, and streams results back:
 
 ```bash
-# Configure your remote host (edit the generated file)
-cp remote.toml.example remote.toml  # or just edit remote.toml directly
+# Configure your remote host
+vi remote.toml
 
 # Verify connectivity and GPU
 bash remote_run.sh --check
@@ -100,13 +60,18 @@ bash remote_run.sh > run.log 2>&1
 grep "^val_bpb:" run.log
 ```
 
-The script handles: SSH connectivity, code sync via rsync, data preparation on first run, and timeout enforcement on the remote side. Configure the remote host, SSH key, and paths in `remote.toml` (gitignored — credentials stay local).
+The script handles SSH connectivity, code sync (rsync), data preparation on first run, and timeout enforcement on the remote side. A `Dockerfile` is included for reproducible environments (CUDA 12.8, Python 3.10, pinned dependencies).
 
-A `Dockerfile` is included for reproducible environments (CUDA 12.8, Python 3.10, pinned dependencies).
+Configuration lives in `remote.toml` (gitignored):
+- `host` — SSH hostname or IP
+- `user` — SSH user (default: `ubuntu`)
+- `key_path` — path to SSH key
+- `workspace` — remote working directory
+- `num_gpus` — set >1 for multi-GPU (uses `torchrun` automatically)
 
-### Multi-GPU distributed training
+## Multi-GPU distributed training
 
-`train.py` supports multi-GPU training via PyTorch's `torchrun`. Each GPU reads a disjoint subset of training data shards, and gradients are averaged across all GPUs before the optimizer step (including the Muon optimizer's Newton-Schulz orthogonalization). The effective batch size scales linearly with GPU count.
+`train.py` supports multi-GPU training via `torchrun`. Each GPU reads a disjoint subset of training data shards, gradients are averaged across GPUs before the optimizer step. The effective batch size scales linearly with GPU count.
 
 ```bash
 # Local multi-GPU (e.g. 4 GPUs)
@@ -116,13 +81,11 @@ uv run torchrun --nproc_per_node=4 train.py
 bash remote_run.sh > run.log 2>&1
 ```
 
-Key details:
-- **Backward compatible** — `uv run train.py` still works for single-GPU, no changes needed.
-- **Same output format** — only rank 0 prints and runs evaluation, so `grep "^val_bpb:" run.log` works identically.
-- **Data requirement** — you need at least as many training shards as GPUs. Download more with `uv run prepare.py --num-shards N`.
-- **5-minute budget unchanged** — each experiment still runs for 5 minutes, but processes more data with more GPUs.
+- **Backward compatible** — `uv run train.py` still works for single GPU, unchanged.
+- **Same output format** — only rank 0 prints and runs evaluation. `grep "^val_bpb:" run.log` works identically.
+- **Data requirement** — need at least as many training shards as GPUs. Download more with `uv run prepare.py --num-shards N`.
 
-### Project structure (extended)
+## Project structure
 
 ```
 prepare.py      — constants, data prep + runtime utilities (do not modify)
@@ -133,6 +96,12 @@ remote_run.sh   — remote GPU execution script
 remote.toml     — remote host configuration (gitignored)
 Dockerfile      — reproducible CUDA environment
 ```
+
+## Design choices
+
+- **Single file to modify.** The agent only touches `train.py`. Keeps scope manageable and diffs reviewable.
+- **Fixed time budget.** 5 minutes per experiment. Makes results directly comparable regardless of what the agent changes.
+- **Self-contained.** PyTorch and a few small packages. Multi-GPU via `torchrun`, single-GPU by default.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pyproject.toml  — dependencies
 
 - **Single file to modify.** The agent only touches `train.py`. This keeps the scope manageable and diffs reviewable.
 - **Fixed time budget.** Training always runs for exactly 5 minutes, regardless of your specific platform. This means you can expect approx 12 experiments/hour and approx 100 experiments while you sleep. There are two upsides of this design decision. First, this makes experiments directly comparable regardless of what the agent changes (model size, batch size, architecture, etc). Second, this means that autoresearch will find the most optimal model for your platform in that time budget. The downside is that your runs (and results) become not comparable to other people running on other compute platforms.
-- **Self-contained.** No external dependencies beyond PyTorch and a few small packages. No distributed training, no complex configs. One GPU, one file, one metric.
+- **Self-contained.** No external dependencies beyond PyTorch and a few small packages. One file, one metric. Multi-GPU is supported via `torchrun` but single-GPU remains the default.
 
 ## Platform support
 
@@ -79,6 +79,60 @@ Seeing as there seems to be a lot of interest in tinkering with autoresearch on 
 7. You'll want to lower `TOTAL_BATCH_SIZE` a lot, but keep it powers of 2, e.g. down to `2**14` (~16K) or so even, hard to tell.
 
 I think these would be the reasonable hyperparameters to play with. Ask your favorite coding agent for help and copy paste them this guide, as well as the full source code.
+
+## Remote & multi-GPU execution
+
+While the default setup targets a single local GPU, the repo also supports running experiments on remote GPU machines and scaling across multiple GPUs.
+
+### Remote execution
+
+The `remote_run.sh` script is a drop-in replacement for `uv run train.py` that transparently syncs your code to a remote GPU machine, runs training, and streams results back:
+
+```bash
+# Configure your remote host (edit the generated file)
+cp remote.toml.example remote.toml  # or just edit remote.toml directly
+
+# Verify connectivity and GPU
+bash remote_run.sh --check
+
+# Run an experiment remotely (same interface as local)
+bash remote_run.sh > run.log 2>&1
+grep "^val_bpb:" run.log
+```
+
+The script handles: SSH connectivity, code sync via rsync, data preparation on first run, and timeout enforcement on the remote side. Configure the remote host, SSH key, and paths in `remote.toml` (gitignored — credentials stay local).
+
+A `Dockerfile` is included for reproducible environments (CUDA 12.8, Python 3.10, pinned dependencies).
+
+### Multi-GPU distributed training
+
+`train.py` supports multi-GPU training via PyTorch's `torchrun`. Each GPU reads a disjoint subset of training data shards, and gradients are averaged across all GPUs before the optimizer step (including the Muon optimizer's Newton-Schulz orthogonalization). The effective batch size scales linearly with GPU count.
+
+```bash
+# Local multi-GPU (e.g. 4 GPUs)
+uv run torchrun --nproc_per_node=4 train.py
+
+# Remote multi-GPU (set num_gpus in remote.toml)
+bash remote_run.sh > run.log 2>&1
+```
+
+Key details:
+- **Backward compatible** — `uv run train.py` still works for single-GPU, no changes needed.
+- **Same output format** — only rank 0 prints and runs evaluation, so `grep "^val_bpb:" run.log` works identically.
+- **Data requirement** — you need at least as many training shards as GPUs. Download more with `uv run prepare.py --num-shards N`.
+- **5-minute budget unchanged** — each experiment still runs for 5 minutes, but processes more data with more GPUs.
+
+### Project structure (extended)
+
+```
+prepare.py      — constants, data prep + runtime utilities (do not modify)
+train.py        — model, optimizer, training loop (agent modifies this)
+program.md      — agent instructions
+pyproject.toml  — dependencies
+remote_run.sh   — remote GPU execution script
+remote.toml     — remote host configuration (gitignored)
+Dockerfile      — reproducible CUDA environment
+```
 
 ## Notable forks
 

--- a/program.md
+++ b/program.md
@@ -20,7 +20,16 @@ Once you get confirmation, kick off the experimentation.
 
 ## Experimentation
 
-Each experiment runs on a single GPU. The training script runs for a **fixed time budget of 5 minutes** (wall clock training time, excluding startup/compilation). You launch it simply as: `uv run train.py`.
+The training script runs for a **fixed time budget of 5 minutes** (wall clock training time, excluding startup/compilation).
+
+**Launch command** depends on where the GPU is:
+- **Local, single GPU**: `uv run train.py`
+- **Local, multi-GPU**: `uv run torchrun --nproc_per_node=N train.py`
+- **Remote GPU**: `bash remote_run.sh` (syncs code to remote, runs training, streams results back — set `num_gpus` in `remote.toml` for multi-GPU)
+
+If using a remote GPU, verify the connection first: `bash remote_run.sh --check`. The remote host is configured in `remote.toml`.
+
+**Distributed training notes**: `train.py` automatically detects distributed mode via `torchrun` environment variables. Each GPU processes its own copy of the data. Gradients are averaged across GPUs before the optimizer step. The effective batch size scales linearly with GPU count. Only rank 0 prints output and runs evaluation — the output format is identical to single-GPU.
 
 **What you CAN do:**
 - Modify `train.py` — this is the only file you edit. Everything is fair game: model architecture, optimizer, hyperparameters, training loop, batch size, model size, etc.
@@ -96,7 +105,7 @@ LOOP FOREVER:
 1. Look at the git state: the current branch/commit we're on
 2. Tune `train.py` with an experimental idea by directly hacking the code.
 3. git commit
-4. Run the experiment: `uv run train.py > run.log 2>&1` (redirect everything — do NOT use tee or let output flood your context)
+4. Run the experiment: `uv run train.py > run.log 2>&1` or `bash remote_run.sh > run.log 2>&1` (redirect everything — do NOT use tee or let output flood your context)
 5. Read out the results: `grep "^val_bpb:\|^peak_vram_mb:" run.log`
 6. If the grep output is empty, the run crashed. Run `tail -n 50 run.log` to read the Python stack trace and attempt a fix. If you can't get things to work after more than a few attempts, give up.
 7. Record the results in the tsv (NOTE: do not commit the results.tsv file, leave it untracked by git)

--- a/program.md
+++ b/program.md
@@ -29,7 +29,7 @@ The training script runs for a **fixed time budget of 5 minutes** (wall clock tr
 
 If using a remote GPU, verify the connection first: `bash remote_run.sh --check`. The remote host is configured in `remote.toml`.
 
-**Distributed training notes**: `train.py` automatically detects distributed mode via `torchrun` environment variables. Each GPU processes its own copy of the data. Gradients are averaged across GPUs before the optimizer step. The effective batch size scales linearly with GPU count. Only rank 0 prints output and runs evaluation — the output format is identical to single-GPU.
+**Distributed training notes**: `train.py` automatically detects distributed mode via `torchrun` environment variables. Each GPU reads a disjoint shard of the training data (parquet files are partitioned per rank). Gradients are averaged across GPUs before the optimizer step. The effective batch size scales linearly with GPU count. Only rank 0 prints output and runs evaluation — the output format is identical to single-GPU.
 
 **What you CAN do:**
 - Modify `train.py` — this is the only file you edit. Everything is fair game: model architecture, optimizer, hyperparameters, training loop, batch size, model size, etc.

--- a/remote_run.sh
+++ b/remote_run.sh
@@ -21,7 +21,9 @@ get_config() {
     local key="$1"
     local default="${2:-}"
     local val
-    val=$(grep -E "^${key}\s*=" "$CONFIG" 2>/dev/null | head -1 | sed 's/^[^=]*=\s*//' | sed 's/\s*#.*//' | tr -d '"' | tr -d "'")
+    val=$(grep -E "^${key}\s*=" "$CONFIG" 2>/dev/null | head -1 \
+        | sed -E 's/^[^=]*=[[:space:]]*([^#]*).*/\1/' | tr -d '"' | tr -d "'" \
+        | sed 's/[[:space:]]*$//')
     if [ -z "$val" ]; then
         echo "$default"
     else
@@ -29,8 +31,17 @@ get_config() {
     fi
 }
 
+# Validate that a config value contains only safe path characters
+validate_path() {
+    local name="$1" val="$2"
+    if [[ ! "$val" =~ ^[a-zA-Z0-9_./:~-]+$ ]]; then
+        echo "ERROR: '$name' contains unsafe characters: $val" >&2
+        exit 1
+    fi
+}
+
 HOST=$(get_config "host")
-USER=$(get_config "user" "ubuntu")
+REMOTE_USER=$(get_config "user" "ubuntu")
 KEY_PATH=$(get_config "key_path" "~/.ssh/id_rsa")
 WORKSPACE=$(get_config "workspace" "/workspace/autoresearch")
 CACHE_DIR=$(get_config "cache_dir" "/root/.cache/autoresearch")
@@ -43,9 +54,21 @@ RUN_TIMEOUT=$(get_config "run_timeout" "900")
 # Expand tilde in key path
 KEY_PATH="${KEY_PATH/#\~/$HOME}"
 
-SSH_OPTS="-o ConnectTimeout=$CONNECT_TIMEOUT -o StrictHostKeyChecking=accept-new -o BatchMode=yes -i $KEY_PATH"
-SSH_CMD="ssh $SSH_OPTS ${USER}@${HOST}"
-SCP_CMD="scp $SSH_OPTS"
+# Validate inputs that get interpolated into shell commands
+validate_path "host" "$HOST" || true  # host may be empty (caught below)
+validate_path "workspace" "$WORKSPACE"
+validate_path "cache_dir" "$CACHE_DIR"
+validate_path "key_path" "$KEY_PATH"
+[ -n "$IMAGE" ] && validate_path "image" "$IMAGE"
+
+# Build SSH command as a function to ensure proper quoting
+run_ssh() {
+    ssh -o "ConnectTimeout=$CONNECT_TIMEOUT" \
+        -o "StrictHostKeyChecking=accept-new" \
+        -o "BatchMode=yes" \
+        -i "$KEY_PATH" \
+        "${REMOTE_USER}@${HOST}" "$@"
+}
 
 # ---------------------------------------------------------------------------
 # Validation
@@ -67,9 +90,9 @@ fi
 # ---------------------------------------------------------------------------
 
 check_connection() {
-    echo "Checking connectivity to ${USER}@${HOST}..." >&2
-    if ! $SSH_CMD "nvidia-smi --query-gpu=name,memory.total --format=csv,noheader" 2>/dev/null; then
-        echo "ERROR: Cannot reach ${USER}@${HOST} or no GPU detected" >&2
+    echo "Checking connectivity to ${REMOTE_USER}@${HOST}..." >&2
+    if ! run_ssh "nvidia-smi --query-gpu=name,memory.total --format=csv,noheader" 2>/dev/null; then
+        echo "ERROR: Cannot reach ${REMOTE_USER}@${HOST} or no GPU detected" >&2
         exit 1
     fi
     echo "Connection OK, GPU available." >&2
@@ -86,10 +109,10 @@ fi
 
 sync_code() {
     echo "Syncing code to ${HOST}:${WORKSPACE}..." >&2
-    $SSH_CMD "mkdir -p $WORKSPACE" 2>/dev/null
+    run_ssh "mkdir -p '${WORKSPACE}'" 2>/dev/null
 
     rsync -az --delete \
-        -e "ssh $SSH_OPTS" \
+        -e "ssh -o ConnectTimeout=$CONNECT_TIMEOUT -o StrictHostKeyChecking=accept-new -o BatchMode=yes -i $KEY_PATH" \
         --exclude '.git' \
         --exclude '.venv' \
         --exclude '__pycache__' \
@@ -99,7 +122,7 @@ sync_code() {
         --exclude '.remote_state' \
         --exclude 'worktrees' \
         --exclude 'dev' \
-        "$SCRIPT_DIR/" "${USER}@${HOST}:${WORKSPACE}/"
+        "$SCRIPT_DIR/" "${REMOTE_USER}@${HOST}:${WORKSPACE}/"
 
     echo "Code synced." >&2
 }
@@ -110,11 +133,11 @@ sync_code() {
 
 ensure_data() {
     echo "Checking remote data..." >&2
-    if $SSH_CMD "test -d ${CACHE_DIR}/data && test -f ${CACHE_DIR}/tokenizer/tokenizer.pkl" 2>/dev/null; then
+    if run_ssh "test -d '${CACHE_DIR}/data' && test -f '${CACHE_DIR}/tokenizer/tokenizer.pkl'" 2>/dev/null; then
         echo "Remote data OK." >&2
     else
         echo "Data not found on remote. Running prepare.py..." >&2
-        $SSH_CMD "cd $WORKSPACE && uv run prepare.py" >&2
+        run_ssh "cd '${WORKSPACE}' && uv run prepare.py" >&2
         echo "Data preparation complete." >&2
     fi
 }
@@ -134,7 +157,7 @@ run_training() {
     local train_cmd
 
     if [ "$NUM_GPUS" -gt 1 ]; then
-        train_cmd="uv run torchrun --nproc_per_node=$NUM_GPUS train.py"
+        train_cmd="uv run torchrun --nproc_per_node=${NUM_GPUS} train.py"
     else
         train_cmd="uv run train.py"
     fi
@@ -142,16 +165,23 @@ run_training() {
     local remote_cmd
     if [ "$USE_CONTAINER" = "true" ] && [ -n "$IMAGE" ]; then
         remote_cmd="docker run --rm --gpus all \
-            -v ${CACHE_DIR}:/root/.cache/autoresearch \
-            -v ${WORKSPACE}:/workspace/autoresearch \
-            ${IMAGE} $train_cmd"
+            -v '${CACHE_DIR}':/root/.cache/autoresearch \
+            -v '${WORKSPACE}':/workspace/autoresearch \
+            '${IMAGE}' ${train_cmd}"
     else
-        remote_cmd="cd $WORKSPACE && $train_cmd"
+        remote_cmd="cd '${WORKSPACE}' && ${train_cmd}"
     fi
 
-    # Run with timeout. stdout/stderr stream directly to our stdout/stderr,
-    # so the caller's redirection (> run.log 2>&1) captures everything.
-    timeout "$RUN_TIMEOUT" $SSH_CMD "$remote_cmd"
+    # Run with timeout. Exit code 124 = timeout killed the process.
+    local exit_code=0
+    timeout "$RUN_TIMEOUT" run_ssh "$remote_cmd" || exit_code=$?
+
+    if [ "$exit_code" -eq 124 ]; then
+        echo "ERROR: Run timed out after ${RUN_TIMEOUT} seconds" >&2
+        exit 124
+    elif [ "$exit_code" -ne 0 ]; then
+        exit "$exit_code"
+    fi
 }
 
 # ---------------------------------------------------------------------------

--- a/remote_run.sh
+++ b/remote_run.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# remote_run.sh — Drop-in replacement for "uv run train.py".
+# Syncs train.py to a remote GPU machine, runs training, streams results back.
+#
+# Usage:
+#   bash remote_run.sh > run.log 2>&1        # exactly like the local workflow
+#   bash remote_run.sh --check               # connectivity + GPU check only
+#   bash remote_run.sh --prepare             # run prepare.py on remote (data setup)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG="$SCRIPT_DIR/remote.toml"
+
+# ---------------------------------------------------------------------------
+# Config parsing (simple grep-based, no TOML library needed)
+# ---------------------------------------------------------------------------
+
+get_config() {
+    local key="$1"
+    local default="${2:-}"
+    local val
+    val=$(grep -E "^${key}\s*=" "$CONFIG" 2>/dev/null | head -1 | sed 's/^[^=]*=\s*//' | sed 's/\s*#.*//' | tr -d '"' | tr -d "'")
+    if [ -z "$val" ]; then
+        echo "$default"
+    else
+        echo "$val"
+    fi
+}
+
+HOST=$(get_config "host")
+USER=$(get_config "user" "ubuntu")
+KEY_PATH=$(get_config "key_path" "~/.ssh/id_rsa")
+WORKSPACE=$(get_config "workspace" "/workspace/autoresearch")
+CACHE_DIR=$(get_config "cache_dir" "/root/.cache/autoresearch")
+NUM_GPUS=$(get_config "num_gpus" "1")
+USE_CONTAINER=$(get_config "use_container" "false")
+IMAGE=$(get_config "image")
+CONNECT_TIMEOUT=$(get_config "connect_timeout" "30")
+RUN_TIMEOUT=$(get_config "run_timeout" "900")
+
+# Expand tilde in key path
+KEY_PATH="${KEY_PATH/#\~/$HOME}"
+
+SSH_OPTS="-o ConnectTimeout=$CONNECT_TIMEOUT -o StrictHostKeyChecking=accept-new -o BatchMode=yes -i $KEY_PATH"
+SSH_CMD="ssh $SSH_OPTS ${USER}@${HOST}"
+SCP_CMD="scp $SSH_OPTS"
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+if [ -z "$HOST" ]; then
+    echo "ERROR: 'host' is not set in $CONFIG" >&2
+    echo "Provision a GPU machine and set the IP/hostname in remote.toml" >&2
+    exit 1
+fi
+
+if [ ! -f "$KEY_PATH" ]; then
+    echo "ERROR: SSH key not found at $KEY_PATH" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 1: Connectivity check
+# ---------------------------------------------------------------------------
+
+check_connection() {
+    echo "Checking connectivity to ${USER}@${HOST}..." >&2
+    if ! $SSH_CMD "nvidia-smi --query-gpu=name,memory.total --format=csv,noheader" 2>/dev/null; then
+        echo "ERROR: Cannot reach ${USER}@${HOST} or no GPU detected" >&2
+        exit 1
+    fi
+    echo "Connection OK, GPU available." >&2
+}
+
+if [ "${1:-}" = "--check" ]; then
+    check_connection
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 2: Sync code to remote
+# ---------------------------------------------------------------------------
+
+sync_code() {
+    echo "Syncing code to ${HOST}:${WORKSPACE}..." >&2
+    $SSH_CMD "mkdir -p $WORKSPACE" 2>/dev/null
+
+    rsync -az --delete \
+        -e "ssh $SSH_OPTS" \
+        --exclude '.git' \
+        --exclude '.venv' \
+        --exclude '__pycache__' \
+        --exclude 'run.log' \
+        --exclude 'results.tsv' \
+        --exclude 'remote.toml' \
+        --exclude '.remote_state' \
+        --exclude 'worktrees' \
+        --exclude 'dev' \
+        "$SCRIPT_DIR/" "${USER}@${HOST}:${WORKSPACE}/"
+
+    echo "Code synced." >&2
+}
+
+# ---------------------------------------------------------------------------
+# Phase 3: Ensure data exists on remote
+# ---------------------------------------------------------------------------
+
+ensure_data() {
+    echo "Checking remote data..." >&2
+    if $SSH_CMD "test -d ${CACHE_DIR}/data && test -f ${CACHE_DIR}/tokenizer/tokenizer.pkl" 2>/dev/null; then
+        echo "Remote data OK." >&2
+    else
+        echo "Data not found on remote. Running prepare.py..." >&2
+        $SSH_CMD "cd $WORKSPACE && uv run prepare.py" >&2
+        echo "Data preparation complete." >&2
+    fi
+}
+
+if [ "${1:-}" = "--prepare" ]; then
+    check_connection
+    sync_code
+    ensure_data
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 4: Run training
+# ---------------------------------------------------------------------------
+
+run_training() {
+    local train_cmd
+
+    if [ "$NUM_GPUS" -gt 1 ]; then
+        train_cmd="uv run torchrun --nproc_per_node=$NUM_GPUS train.py"
+    else
+        train_cmd="uv run train.py"
+    fi
+
+    local remote_cmd
+    if [ "$USE_CONTAINER" = "true" ] && [ -n "$IMAGE" ]; then
+        remote_cmd="docker run --rm --gpus all \
+            -v ${CACHE_DIR}:/root/.cache/autoresearch \
+            -v ${WORKSPACE}:/workspace/autoresearch \
+            ${IMAGE} $train_cmd"
+    else
+        remote_cmd="cd $WORKSPACE && $train_cmd"
+    fi
+
+    # Run with timeout. stdout/stderr stream directly to our stdout/stderr,
+    # so the caller's redirection (> run.log 2>&1) captures everything.
+    timeout "$RUN_TIMEOUT" $SSH_CMD "$remote_cmd"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+check_connection
+sync_code
+ensure_data
+run_training

--- a/remote_run.sh
+++ b/remote_run.sh
@@ -44,7 +44,7 @@ HOST=$(get_config "host")
 REMOTE_USER=$(get_config "user" "ubuntu")
 KEY_PATH=$(get_config "key_path" "~/.ssh/id_rsa")
 WORKSPACE=$(get_config "workspace" "/workspace/autoresearch")
-CACHE_DIR=$(get_config "cache_dir" "/root/.cache/autoresearch")
+CACHE_DIR=$(get_config "cache_dir" "~/.cache/autoresearch")
 NUM_GPUS=$(get_config "num_gpus" "1")
 USE_CONTAINER=$(get_config "use_container" "false")
 IMAGE=$(get_config "image")
@@ -162,19 +162,20 @@ run_training() {
         train_cmd="uv run train.py"
     fi
 
+    # Timeout is enforced on the remote side so the training process is killed
+    # even if the SSH connection drops (avoids orphaned GPU jobs).
     local remote_cmd
     if [ "$USE_CONTAINER" = "true" ] && [ -n "$IMAGE" ]; then
-        remote_cmd="docker run --rm --gpus all \
+        remote_cmd="timeout ${RUN_TIMEOUT} docker run --rm --gpus all \
             -v '${CACHE_DIR}':/root/.cache/autoresearch \
             -v '${WORKSPACE}':/workspace/autoresearch \
             '${IMAGE}' ${train_cmd}"
     else
-        remote_cmd="cd '${WORKSPACE}' && ${train_cmd}"
+        remote_cmd="cd '${WORKSPACE}' && timeout ${RUN_TIMEOUT} ${train_cmd}"
     fi
 
-    # Run with timeout. Exit code 124 = timeout killed the process.
     local exit_code=0
-    timeout "$RUN_TIMEOUT" run_ssh "$remote_cmd" || exit_code=$?
+    run_ssh "$remote_cmd" || exit_code=$?
 
     if [ "$exit_code" -eq 124 ]; then
         echo "ERROR: Run timed out after ${RUN_TIMEOUT} seconds" >&2

--- a/train.py
+++ b/train.py
@@ -663,6 +663,9 @@ print0(f"Estimated FLOPs per token: {num_flops_per_token:e}")
 tokens_per_fwdbwd = DEVICE_BATCH_SIZE * MAX_SEQ_LEN
 assert TOTAL_BATCH_SIZE % tokens_per_fwdbwd == 0
 grad_accum_steps = TOTAL_BATCH_SIZE // tokens_per_fwdbwd
+EFFECTIVE_BATCH = (
+    TOTAL_BATCH_SIZE * WORLD_SIZE
+)  # total tokens per optimizer step across all GPUs
 
 optimizer = model.setup_optimizer(
     unembedding_lr=UNEMBEDDING_LR,
@@ -682,7 +685,7 @@ print0(f"Time budget: {TIME_BUDGET}s")
 print0(f"Gradient accumulation steps: {grad_accum_steps}")
 if IS_DISTRIBUTED:
     print0(
-        f"Distributed: {WORLD_SIZE} GPUs, effective batch = {TOTAL_BATCH_SIZE * WORLD_SIZE:,} tokens"
+        f"Distributed: {WORLD_SIZE} GPUs, effective batch = {EFFECTIVE_BATCH:,} tokens"
     )
 
 # Schedules (all based on progress = training_time / TIME_BUDGET)
@@ -773,12 +776,11 @@ while True:
     smooth_train_loss = ema_beta * smooth_train_loss + (1 - ema_beta) * train_loss_f
     debiased_smooth_loss = smooth_train_loss / (1 - ema_beta ** (step + 1))
     pct_done = 100 * progress
-    effective_batch = TOTAL_BATCH_SIZE * WORLD_SIZE
-    tok_per_sec = int(effective_batch / dt)
+    tok_per_sec = int(EFFECTIVE_BATCH / dt)
     mfu = (
         100
         * num_flops_per_token
-        * effective_batch
+        * EFFECTIVE_BATCH
         / dt
         / (H100_BF16_PEAK_FLOPS * WORLD_SIZE)
     )
@@ -806,8 +808,7 @@ while True:
 
 print0()  # newline after \r training log
 
-effective_batch_total = TOTAL_BATCH_SIZE * WORLD_SIZE
-total_tokens = step * effective_batch_total
+total_tokens = step * EFFECTIVE_BATCH
 
 # Final eval (rank 0 only, then broadcast)
 model.eval()
@@ -828,7 +829,7 @@ startup_time = t_start_training - t_start
 steady_state_mfu = (
     100
     * num_flops_per_token
-    * effective_batch_total
+    * EFFECTIVE_BATCH
     * (step - 10)
     / total_training_time
     / (H100_BF16_PEAK_FLOPS * WORLD_SIZE)

--- a/train.py
+++ b/train.py
@@ -5,6 +5,7 @@ Usage: uv run train.py
 """
 
 import os
+
 os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
 os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
 
@@ -16,18 +17,60 @@ from dataclasses import dataclass, asdict
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import torch.distributed as dist
+
+# Distributed setup (set by torchrun, defaults to single-GPU when run standalone)
+RANK = int(os.environ.get("RANK", 0))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", 0))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", 1))
+IS_DISTRIBUTED = WORLD_SIZE > 1
+
+if IS_DISTRIBUTED:
+    dist.init_process_group(backend="nccl")
+    torch.cuda.set_device(LOCAL_RANK)
 
 from kernels import get_kernel
+
 cap = torch.cuda.get_device_capability()
 # varunneal's FA3 is Hopper only, use kernels-community on non-Hopper GPUs
-repo = "varunneal/flash-attention-3" if cap == (9, 0) else "kernels-community/flash-attn3"
+repo = (
+    "varunneal/flash-attention-3" if cap == (9, 0) else "kernels-community/flash-attn3"
+)
 fa3 = get_kernel(repo).flash_attn_interface
 
+import prepare
 from prepare import MAX_SEQ_LEN, TIME_BUDGET, Tokenizer, make_dataloader, evaluate_bpb
+
+# Distributed data sharding: each rank sees a disjoint subset of parquet files
+if IS_DISTRIBUTED:
+    _original_list_parquet_files = prepare.list_parquet_files
+
+    def _rank_filtered_parquet_files():
+        all_files = _original_list_parquet_files()
+        val_path = os.path.join(prepare.DATA_DIR, prepare.VAL_FILENAME)
+        train_files = [f for f in all_files if f != val_path]
+        assert len(train_files) >= WORLD_SIZE, (
+            f"Need at least {WORLD_SIZE} training shards for {WORLD_SIZE} GPUs, "
+            f"but only {len(train_files)} found. Download more shards with: "
+            f"uv run prepare.py --num-shards {WORLD_SIZE + 1}"
+        )
+        rank_files = train_files[RANK::WORLD_SIZE]
+        if os.path.exists(val_path):
+            rank_files.append(val_path)
+        return sorted(rank_files)
+
+    prepare.list_parquet_files = _rank_filtered_parquet_files
+
+
+def print0(*args, **kwargs):
+    if RANK == 0:
+        print(*args, **kwargs)
+
 
 # ---------------------------------------------------------------------------
 # GPT Model
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class GPTConfig:
@@ -72,7 +115,11 @@ class CausalSelfAttention(nn.Module):
         self.c_v = nn.Linear(self.n_embd, self.n_kv_head * self.head_dim, bias=False)
         self.c_proj = nn.Linear(self.n_embd, self.n_embd, bias=False)
         self.ve_gate_channels = 32
-        self.ve_gate = nn.Linear(self.ve_gate_channels, self.n_kv_head, bias=False) if has_ve(layer_idx, config.n_layer) else None
+        self.ve_gate = (
+            nn.Linear(self.ve_gate_channels, self.n_kv_head, bias=False)
+            if has_ve(layer_idx, config.n_layer)
+            else None
+        )
 
     def forward(self, x, ve, cos_sin, window_size):
         B, T, C = x.size()
@@ -83,7 +130,7 @@ class CausalSelfAttention(nn.Module):
         # Value residual (ResFormer): mix in value embedding with input-dependent gate per head
         if ve is not None:
             ve = ve.view(B, T, self.n_kv_head, self.head_dim)
-            gate = 2 * torch.sigmoid(self.ve_gate(x[..., :self.ve_gate_channels]))
+            gate = 2 * torch.sigmoid(self.ve_gate(x[..., : self.ve_gate_channels]))
             v = v + gate.unsqueeze(-1) * ve
 
         cos, sin = cos_sin
@@ -126,20 +173,25 @@ class GPT(nn.Module):
         super().__init__()
         self.config = config
         self.window_sizes = self._compute_window_sizes(config)
-        self.transformer = nn.ModuleDict({
-            "wte": nn.Embedding(config.vocab_size, config.n_embd),
-            "h": nn.ModuleList([Block(config, i) for i in range(config.n_layer)]),
-        })
+        self.transformer = nn.ModuleDict(
+            {
+                "wte": nn.Embedding(config.vocab_size, config.n_embd),
+                "h": nn.ModuleList([Block(config, i) for i in range(config.n_layer)]),
+            }
+        )
         self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)
         self.resid_lambdas = nn.Parameter(torch.ones(config.n_layer))
         self.x0_lambdas = nn.Parameter(torch.zeros(config.n_layer))
         # Value embeddings
         head_dim = config.n_embd // config.n_head
         kv_dim = config.n_kv_head * head_dim
-        self.value_embeds = nn.ModuleDict({
-            str(i): nn.Embedding(config.vocab_size, kv_dim)
-            for i in range(config.n_layer) if has_ve(i, config.n_layer)
-        })
+        self.value_embeds = nn.ModuleDict(
+            {
+                str(i): nn.Embedding(config.vocab_size, kv_dim)
+                for i in range(config.n_layer)
+                if has_ve(i, config.n_layer)
+            }
+        )
         # Rotary embeddings
         self.rotary_seq_len = config.sequence_len * 10
         cos, sin = self._precompute_rotary_embeddings(self.rotary_seq_len, head_dim)
@@ -209,8 +261,12 @@ class GPT(nn.Module):
         """Estimated FLOPs per token (forward + backward)."""
         nparams = sum(p.numel() for p in self.parameters())
         value_embeds_numel = sum(ve.weight.numel() for ve in self.value_embeds.values())
-        nparams_exclude = (self.transformer.wte.weight.numel() + value_embeds_numel +
-                          self.resid_lambdas.numel() + self.x0_lambdas.numel())
+        nparams_exclude = (
+            self.transformer.wte.weight.numel()
+            + value_embeds_numel
+            + self.resid_lambdas.numel()
+            + self.x0_lambdas.numel()
+        )
         h = self.config.n_head
         q = self.config.n_embd // self.config.n_head
         t = self.config.sequence_len
@@ -229,12 +285,23 @@ class GPT(nn.Module):
         scalars = self.resid_lambdas.numel() + self.x0_lambdas.numel()
         total = wte + value_embeds + lm_head + transformer_matrices + scalars
         return {
-            'wte': wte, 'value_embeds': value_embeds, 'lm_head': lm_head,
-            'transformer_matrices': transformer_matrices, 'scalars': scalars, 'total': total,
+            "wte": wte,
+            "value_embeds": value_embeds,
+            "lm_head": lm_head,
+            "transformer_matrices": transformer_matrices,
+            "scalars": scalars,
+            "total": total,
         }
 
-    def setup_optimizer(self, unembedding_lr=0.004, embedding_lr=0.2, matrix_lr=0.02,
-                        weight_decay=0.0, adam_betas=(0.8, 0.95), scalar_lr=0.5):
+    def setup_optimizer(
+        self,
+        unembedding_lr=0.004,
+        embedding_lr=0.2,
+        matrix_lr=0.02,
+        weight_decay=0.0,
+        adam_betas=(0.8, 0.95),
+        scalar_lr=0.5,
+    ):
         model_dim = self.config.n_embd
         matrix_params = list(self.transformer.h.parameters())
         value_embeds_params = list(self.value_embeds.parameters())
@@ -242,30 +309,78 @@ class GPT(nn.Module):
         lm_head_params = list(self.lm_head.parameters())
         resid_params = [self.resid_lambdas]
         x0_params = [self.x0_lambdas]
-        assert len(list(self.parameters())) == (len(matrix_params) + len(embedding_params) +
-            len(lm_head_params) + len(value_embeds_params) + len(resid_params) + len(x0_params))
+        assert len(list(self.parameters())) == (
+            len(matrix_params)
+            + len(embedding_params)
+            + len(lm_head_params)
+            + len(value_embeds_params)
+            + len(resid_params)
+            + len(x0_params)
+        )
         # Scale LR ∝ 1/√dmodel (tuned at 768 dim)
         dmodel_lr_scale = (model_dim / 768) ** -0.5
         print(f"Scaling AdamW LRs by 1/sqrt({model_dim}/768) = {dmodel_lr_scale:.6f}")
         param_groups = [
-            dict(kind='adamw', params=lm_head_params, lr=unembedding_lr * dmodel_lr_scale, betas=adam_betas, eps=1e-10, weight_decay=0.0),
-            dict(kind='adamw', params=embedding_params, lr=embedding_lr * dmodel_lr_scale, betas=adam_betas, eps=1e-10, weight_decay=0.0),
-            dict(kind='adamw', params=value_embeds_params, lr=embedding_lr * dmodel_lr_scale, betas=adam_betas, eps=1e-10, weight_decay=0.0),
-            dict(kind='adamw', params=resid_params, lr=scalar_lr * 0.01, betas=adam_betas, eps=1e-10, weight_decay=0.0),
-            dict(kind='adamw', params=x0_params, lr=scalar_lr, betas=(0.96, 0.95), eps=1e-10, weight_decay=0.0),
+            dict(
+                kind="adamw",
+                params=lm_head_params,
+                lr=unembedding_lr * dmodel_lr_scale,
+                betas=adam_betas,
+                eps=1e-10,
+                weight_decay=0.0,
+            ),
+            dict(
+                kind="adamw",
+                params=embedding_params,
+                lr=embedding_lr * dmodel_lr_scale,
+                betas=adam_betas,
+                eps=1e-10,
+                weight_decay=0.0,
+            ),
+            dict(
+                kind="adamw",
+                params=value_embeds_params,
+                lr=embedding_lr * dmodel_lr_scale,
+                betas=adam_betas,
+                eps=1e-10,
+                weight_decay=0.0,
+            ),
+            dict(
+                kind="adamw",
+                params=resid_params,
+                lr=scalar_lr * 0.01,
+                betas=adam_betas,
+                eps=1e-10,
+                weight_decay=0.0,
+            ),
+            dict(
+                kind="adamw",
+                params=x0_params,
+                lr=scalar_lr,
+                betas=(0.96, 0.95),
+                eps=1e-10,
+                weight_decay=0.0,
+            ),
         ]
         for shape in sorted({p.shape for p in matrix_params}):
             group_params = [p for p in matrix_params if p.shape == shape]
-            param_groups.append(dict(
-                kind='muon', params=group_params, lr=matrix_lr,
-                momentum=0.95, ns_steps=5, beta2=0.95, weight_decay=weight_decay,
-            ))
+            param_groups.append(
+                dict(
+                    kind="muon",
+                    params=group_params,
+                    lr=matrix_lr,
+                    momentum=0.95,
+                    ns_steps=5,
+                    beta2=0.95,
+                    weight_decay=weight_decay,
+                )
+            )
         optimizer = MuonAdamW(param_groups)
         for group in optimizer.param_groups:
             group["initial_lr"] = group["lr"]
         return optimizer
 
-    def forward(self, idx, targets=None, reduction='mean'):
+    def forward(self, idx, targets=None, reduction="mean"):
         B, T = idx.size()
         assert T <= self.cos.size(1)
         cos_sin = self.cos[:, :T], self.sin[:, :T]
@@ -285,10 +400,15 @@ class GPT(nn.Module):
         logits = softcap * torch.tanh(logits / softcap)
 
         if targets is not None:
-            loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1),
-                                   ignore_index=-1, reduction=reduction)
+            loss = F.cross_entropy(
+                logits.view(-1, logits.size(-1)),
+                targets.view(-1),
+                ignore_index=-1,
+                reduction=reduction,
+            )
             return loss
         return logits
+
 
 # ---------------------------------------------------------------------------
 # Optimizer (MuonAdamW, single GPU only)
@@ -302,20 +422,34 @@ polar_express_coeffs = [
     (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
 ]
 
+
 @torch.compile(dynamic=False, fullgraph=True)
-def adamw_step_fused(p, grad, exp_avg, exp_avg_sq, step_t, lr_t, beta1_t, beta2_t, eps_t, wd_t):
+def adamw_step_fused(
+    p, grad, exp_avg, exp_avg_sq, step_t, lr_t, beta1_t, beta2_t, eps_t, wd_t
+):
     p.mul_(1 - lr_t * wd_t)
     exp_avg.lerp_(grad, 1 - beta1_t)
     exp_avg_sq.lerp_(grad.square(), 1 - beta2_t)
-    bias1 = 1 - beta1_t ** step_t
-    bias2 = 1 - beta2_t ** step_t
+    bias1 = 1 - beta1_t**step_t
+    bias2 = 1 - beta2_t**step_t
     denom = (exp_avg_sq / bias2).sqrt() + eps_t
     step_size = lr_t / bias1
     p.add_(exp_avg / denom, alpha=-step_size)
 
+
 @torch.compile(dynamic=False, fullgraph=True)
-def muon_step_fused(stacked_grads, stacked_params, momentum_buffer, second_momentum_buffer,
-                    momentum_t, lr_t, wd_t, beta2_t, ns_steps, red_dim):
+def muon_step_fused(
+    stacked_grads,
+    stacked_params,
+    momentum_buffer,
+    second_momentum_buffer,
+    momentum_t,
+    lr_t,
+    wd_t,
+    beta2_t,
+    ns_steps,
+    red_dim,
+):
     # Nesterov momentum
     momentum = momentum_t.to(stacked_grads.dtype)
     momentum_buffer.lerp_(stacked_grads, 1 - momentum)
@@ -340,7 +474,9 @@ def muon_step_fused(stacked_grads, stacked_params, momentum_buffer, second_momen
     red_dim_size = g.size(red_dim)
     v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True) * red_dim_size
     v_norm = v_norm_sq.sqrt()
-    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    second_momentum_buffer.lerp_(
+        v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2
+    )
     step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt()
     scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
     v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt()
@@ -371,28 +507,37 @@ class MuonAdamW(torch.optim.Optimizer):
         self._muon_beta2_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
 
     def _step_adamw(self, group):
-        for p in group['params']:
+        for p in group["params"]:
             if p.grad is None:
                 continue
             grad = p.grad
             state = self.state[p]
             if not state:
-                state['step'] = 0
-                state['exp_avg'] = torch.zeros_like(p)
-                state['exp_avg_sq'] = torch.zeros_like(p)
-            state['step'] += 1
-            self._adamw_step_t.fill_(state['step'])
-            self._adamw_lr_t.fill_(group['lr'])
-            self._adamw_beta1_t.fill_(group['betas'][0])
-            self._adamw_beta2_t.fill_(group['betas'][1])
-            self._adamw_eps_t.fill_(group['eps'])
-            self._adamw_wd_t.fill_(group['weight_decay'])
-            adamw_step_fused(p, grad, state['exp_avg'], state['exp_avg_sq'],
-                            self._adamw_step_t, self._adamw_lr_t, self._adamw_beta1_t,
-                            self._adamw_beta2_t, self._adamw_eps_t, self._adamw_wd_t)
+                state["step"] = 0
+                state["exp_avg"] = torch.zeros_like(p)
+                state["exp_avg_sq"] = torch.zeros_like(p)
+            state["step"] += 1
+            self._adamw_step_t.fill_(state["step"])
+            self._adamw_lr_t.fill_(group["lr"])
+            self._adamw_beta1_t.fill_(group["betas"][0])
+            self._adamw_beta2_t.fill_(group["betas"][1])
+            self._adamw_eps_t.fill_(group["eps"])
+            self._adamw_wd_t.fill_(group["weight_decay"])
+            adamw_step_fused(
+                p,
+                grad,
+                state["exp_avg"],
+                state["exp_avg_sq"],
+                self._adamw_step_t,
+                self._adamw_lr_t,
+                self._adamw_beta1_t,
+                self._adamw_beta2_t,
+                self._adamw_eps_t,
+                self._adamw_wd_t,
+            )
 
     def _step_muon(self, group):
-        params = group['params']
+        params = group["params"]
         if not params:
             return
         p = params[0]
@@ -400,54 +545,71 @@ class MuonAdamW(torch.optim.Optimizer):
         num_params = len(params)
         shape, device, dtype = p.shape, p.device, p.dtype
         if "momentum_buffer" not in state:
-            state["momentum_buffer"] = torch.zeros(num_params, *shape, dtype=dtype, device=device)
+            state["momentum_buffer"] = torch.zeros(
+                num_params, *shape, dtype=dtype, device=device
+            )
         if "second_momentum_buffer" not in state:
-            state_shape = (num_params, shape[-2], 1) if shape[-2] >= shape[-1] else (num_params, 1, shape[-1])
-            state["second_momentum_buffer"] = torch.zeros(state_shape, dtype=dtype, device=device)
+            state_shape = (
+                (num_params, shape[-2], 1)
+                if shape[-2] >= shape[-1]
+                else (num_params, 1, shape[-1])
+            )
+            state["second_momentum_buffer"] = torch.zeros(
+                state_shape, dtype=dtype, device=device
+            )
         red_dim = -1 if shape[-2] >= shape[-1] else -2
         stacked_grads = torch.stack([p.grad for p in params])
         stacked_params = torch.stack(params)
         self._muon_momentum_t.fill_(group["momentum"])
         self._muon_beta2_t.fill_(group["beta2"] if group["beta2"] is not None else 0.0)
-        self._muon_lr_t.fill_(group["lr"] * max(1.0, shape[-2] / shape[-1])**0.5)
+        self._muon_lr_t.fill_(group["lr"] * max(1.0, shape[-2] / shape[-1]) ** 0.5)
         self._muon_wd_t.fill_(group["weight_decay"])
-        muon_step_fused(stacked_grads, stacked_params,
-                        state["momentum_buffer"], state["second_momentum_buffer"],
-                        self._muon_momentum_t, self._muon_lr_t, self._muon_wd_t,
-                        self._muon_beta2_t, group["ns_steps"], red_dim)
+        muon_step_fused(
+            stacked_grads,
+            stacked_params,
+            state["momentum_buffer"],
+            state["second_momentum_buffer"],
+            self._muon_momentum_t,
+            self._muon_lr_t,
+            self._muon_wd_t,
+            self._muon_beta2_t,
+            group["ns_steps"],
+            red_dim,
+        )
         torch._foreach_copy_(params, list(stacked_params.unbind(0)))
 
     @torch.no_grad()
     def step(self):
         for group in self.param_groups:
-            if group['kind'] == 'adamw':
+            if group["kind"] == "adamw":
                 self._step_adamw(group)
-            elif group['kind'] == 'muon':
+            elif group["kind"] == "muon":
                 self._step_muon(group)
+
 
 # ---------------------------------------------------------------------------
 # Hyperparameters (edit these directly, no CLI flags needed)
 # ---------------------------------------------------------------------------
 
 # Model architecture
-ASPECT_RATIO = 64       # model_dim = depth * ASPECT_RATIO
-HEAD_DIM = 128          # target head dimension for attention
-WINDOW_PATTERN = "SSSL" # sliding window pattern: L=full, S=half context
+ASPECT_RATIO = 64  # model_dim = depth * ASPECT_RATIO
+HEAD_DIM = 128  # target head dimension for attention
+WINDOW_PATTERN = "SSSL"  # sliding window pattern: L=full, S=half context
 
 # Optimization
-TOTAL_BATCH_SIZE = 2**19 # ~524K tokens per optimizer step
-EMBEDDING_LR = 0.6      # learning rate for token embeddings (Adam)
+TOTAL_BATCH_SIZE = 2**19  # ~524K tokens per optimizer step
+EMBEDDING_LR = 0.6  # learning rate for token embeddings (Adam)
 UNEMBEDDING_LR = 0.004  # learning rate for lm_head (Adam)
-MATRIX_LR = 0.04        # learning rate for matrix parameters (Muon)
-SCALAR_LR = 0.5         # learning rate for per-layer scalars (Adam)
-WEIGHT_DECAY = 0.2      # cautious weight decay for Muon
-ADAM_BETAS = (0.8, 0.95) # Adam beta1, beta2
-WARMUP_RATIO = 0.0      # fraction of time budget for LR warmup
-WARMDOWN_RATIO = 0.5    # fraction of time budget for LR warmdown
-FINAL_LR_FRAC = 0.0     # final LR as fraction of initial
+MATRIX_LR = 0.04  # learning rate for matrix parameters (Muon)
+SCALAR_LR = 0.5  # learning rate for per-layer scalars (Adam)
+WEIGHT_DECAY = 0.2  # cautious weight decay for Muon
+ADAM_BETAS = (0.8, 0.95)  # Adam beta1, beta2
+WARMUP_RATIO = 0.0  # fraction of time budget for LR warmup
+WARMDOWN_RATIO = 0.5  # fraction of time budget for LR warmdown
+FINAL_LR_FRAC = 0.0  # final LR as fraction of initial
 
 # Model size
-DEPTH = 8               # number of transformer layers
+DEPTH = 8  # number of transformer layers
 DEVICE_BATCH_SIZE = 128  # per-device batch size (reduce if OOM)
 
 # ---------------------------------------------------------------------------
@@ -458,26 +620,32 @@ t_start = time.time()
 torch.manual_seed(42)
 torch.cuda.manual_seed(42)
 torch.set_float32_matmul_precision("high")
-device = torch.device("cuda")
+device = torch.device(f"cuda:{LOCAL_RANK}")
 autocast_ctx = torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16)
 H100_BF16_PEAK_FLOPS = 989.5e12
 
 tokenizer = Tokenizer.from_directory()
 vocab_size = tokenizer.get_vocab_size()
-print(f"Vocab size: {vocab_size:,}")
+print0(f"Vocab size: {vocab_size:,}")
+
 
 def build_model_config(depth):
     base_dim = depth * ASPECT_RATIO
     model_dim = ((base_dim + HEAD_DIM - 1) // HEAD_DIM) * HEAD_DIM
     num_heads = model_dim // HEAD_DIM
     return GPTConfig(
-        sequence_len=MAX_SEQ_LEN, vocab_size=vocab_size,
-        n_layer=depth, n_head=num_heads, n_kv_head=num_heads, n_embd=model_dim,
+        sequence_len=MAX_SEQ_LEN,
+        vocab_size=vocab_size,
+        n_layer=depth,
+        n_head=num_heads,
+        n_kv_head=num_heads,
+        n_embd=model_dim,
         window_pattern=WINDOW_PATTERN,
     )
 
+
 config = build_model_config(DEPTH)
-print(f"Model config: {asdict(config)}")
+print0(f"Model config: {asdict(config)}")
 
 with torch.device("meta"):
     model = GPT(config)
@@ -485,12 +653,12 @@ model.to_empty(device=device)
 model.init_weights()
 
 param_counts = model.num_scaling_params()
-print("Parameter counts:")
+print0("Parameter counts:")
 for key, value in param_counts.items():
-    print(f"  {key:24s}: {value:,}")
-num_params = param_counts['total']
+    print0(f"  {key:24s}: {value:,}")
+num_params = param_counts["total"]
 num_flops_per_token = model.estimate_flops()
-print(f"Estimated FLOPs per token: {num_flops_per_token:e}")
+print0(f"Estimated FLOPs per token: {num_flops_per_token:e}")
 
 tokens_per_fwdbwd = DEVICE_BATCH_SIZE * MAX_SEQ_LEN
 assert TOTAL_BATCH_SIZE % tokens_per_fwdbwd == 0
@@ -510,10 +678,15 @@ model = torch.compile(model, dynamic=False)
 train_loader = make_dataloader(tokenizer, DEVICE_BATCH_SIZE, MAX_SEQ_LEN, "train")
 x, y, epoch = next(train_loader)  # prefetch first batch
 
-print(f"Time budget: {TIME_BUDGET}s")
-print(f"Gradient accumulation steps: {grad_accum_steps}")
+print0(f"Time budget: {TIME_BUDGET}s")
+print0(f"Gradient accumulation steps: {grad_accum_steps}")
+if IS_DISTRIBUTED:
+    print0(
+        f"Distributed: {WORLD_SIZE} GPUs, effective batch = {TOTAL_BATCH_SIZE * WORLD_SIZE:,} tokens"
+    )
 
 # Schedules (all based on progress = training_time / TIME_BUDGET)
+
 
 def get_lr_multiplier(progress):
     if progress < WARMUP_RATIO:
@@ -524,12 +697,15 @@ def get_lr_multiplier(progress):
         cooldown = (1.0 - progress) / WARMDOWN_RATIO
         return cooldown * 1.0 + (1 - cooldown) * FINAL_LR_FRAC
 
+
 def get_muon_momentum(step):
     frac = min(step / 300, 1)
     return (1 - frac) * 0.85 + frac * 0.95
 
+
 def get_weight_decay(progress):
     return WEIGHT_DECAY * (1 - progress)
+
 
 # ---------------------------------------------------------------------------
 # Training loop
@@ -551,6 +727,13 @@ while True:
         loss.backward()
         x, y, epoch = next(train_loader)
 
+    # All-reduce gradients across ranks (must happen before optimizer step so
+    # Muon's Newton-Schulz orthogonalization sees identical averaged gradients)
+    if IS_DISTRIBUTED:
+        for p in model.parameters():
+            if p.grad is not None:
+                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
     # Progress and schedules
     progress = min(total_training_time / TIME_BUDGET, 1.0)
     lrm = get_lr_multiplier(progress)
@@ -558,7 +741,7 @@ while True:
     muon_weight_decay = get_weight_decay(progress)
     for group in optimizer.param_groups:
         group["lr"] = group["initial_lr"] * lrm
-        if group['kind'] == 'muon':
+        if group["kind"] == "muon":
             group["momentum"] = muon_momentum
             group["weight_decay"] = muon_weight_decay
     optimizer.step()
@@ -566,9 +749,16 @@ while True:
 
     train_loss_f = train_loss.item()
 
-    # Fast fail: abort if loss is exploding or NaN
-    if math.isnan(train_loss_f) or train_loss_f > 100:
-        print("FAIL")
+    # Fast fail: abort if loss is exploding or NaN (coordinated across ranks)
+    should_fail = math.isnan(train_loss_f) or train_loss_f > 100
+    if IS_DISTRIBUTED:
+        fail_flag = torch.tensor(int(should_fail), device=device)
+        dist.all_reduce(fail_flag, op=dist.ReduceOp.MAX)
+        should_fail = fail_flag.item() > 0
+    if should_fail:
+        print0("FAIL")
+        if IS_DISTRIBUTED:
+            dist.destroy_process_group()
         exit(1)
 
     torch.cuda.synchronize()
@@ -581,13 +771,24 @@ while True:
     # Logging
     ema_beta = 0.9
     smooth_train_loss = ema_beta * smooth_train_loss + (1 - ema_beta) * train_loss_f
-    debiased_smooth_loss = smooth_train_loss / (1 - ema_beta**(step + 1))
+    debiased_smooth_loss = smooth_train_loss / (1 - ema_beta ** (step + 1))
     pct_done = 100 * progress
-    tok_per_sec = int(TOTAL_BATCH_SIZE / dt)
-    mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE / dt / H100_BF16_PEAK_FLOPS
+    effective_batch = TOTAL_BATCH_SIZE * WORLD_SIZE
+    tok_per_sec = int(effective_batch / dt)
+    mfu = (
+        100
+        * num_flops_per_token
+        * effective_batch
+        / dt
+        / (H100_BF16_PEAK_FLOPS * WORLD_SIZE)
+    )
     remaining = max(0, TIME_BUDGET - total_training_time)
 
-    print(f"\rstep {step:05d} ({pct_done:.1f}%) | loss: {debiased_smooth_loss:.6f} | lrm: {lrm:.2f} | dt: {dt*1000:.0f}ms | tok/sec: {tok_per_sec:,} | mfu: {mfu:.1f}% | epoch: {epoch} | remaining: {remaining:.0f}s    ", end="", flush=True)
+    print0(
+        f"\rstep {step:05d} ({pct_done:.1f}%) | loss: {debiased_smooth_loss:.6f} | lrm: {lrm:.2f} | dt: {dt * 1000:.0f}ms | tok/sec: {tok_per_sec:,} | mfu: {mfu:.1f}% | epoch: {epoch} | remaining: {remaining:.0f}s    ",
+        end="",
+        flush=True,
+    )
 
     # GC management (Python's GC causes ~500ms stalls)
     if step == 0:
@@ -603,28 +804,49 @@ while True:
     if step > 10 and total_training_time >= TIME_BUDGET:
         break
 
-print()  # newline after \r training log
+print0()  # newline after \r training log
 
-total_tokens = step * TOTAL_BATCH_SIZE
+effective_batch_total = TOTAL_BATCH_SIZE * WORLD_SIZE
+total_tokens = step * effective_batch_total
 
-# Final eval
+# Final eval (rank 0 only, then broadcast)
 model.eval()
-with autocast_ctx:
-    val_bpb = evaluate_bpb(model, tokenizer, DEVICE_BATCH_SIZE)
+if RANK == 0:
+    with autocast_ctx:
+        val_bpb = evaluate_bpb(model, tokenizer, DEVICE_BATCH_SIZE)
+else:
+    val_bpb = 0.0
+
+if IS_DISTRIBUTED:
+    val_bpb_t = torch.tensor(val_bpb, device=device)
+    dist.broadcast(val_bpb_t, src=0)
+    val_bpb = val_bpb_t.item()
 
 # Final summary
 t_end = time.time()
 startup_time = t_start_training - t_start
-steady_state_mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE * (step - 10) / total_training_time / H100_BF16_PEAK_FLOPS if total_training_time > 0 else 0
+steady_state_mfu = (
+    100
+    * num_flops_per_token
+    * effective_batch_total
+    * (step - 10)
+    / total_training_time
+    / (H100_BF16_PEAK_FLOPS * WORLD_SIZE)
+    if total_training_time > 0
+    else 0
+)
 peak_vram_mb = torch.cuda.max_memory_allocated() / 1024 / 1024
 
-print("---")
-print(f"val_bpb:          {val_bpb:.6f}")
-print(f"training_seconds: {total_training_time:.1f}")
-print(f"total_seconds:    {t_end - t_start:.1f}")
-print(f"peak_vram_mb:     {peak_vram_mb:.1f}")
-print(f"mfu_percent:      {steady_state_mfu:.2f}")
-print(f"total_tokens_M:   {total_tokens / 1e6:.1f}")
-print(f"num_steps:        {step}")
-print(f"num_params_M:     {num_params / 1e6:.1f}")
-print(f"depth:            {DEPTH}")
+print0("---")
+print0(f"val_bpb:          {val_bpb:.6f}")
+print0(f"training_seconds: {total_training_time:.1f}")
+print0(f"total_seconds:    {t_end - t_start:.1f}")
+print0(f"peak_vram_mb:     {peak_vram_mb:.1f}")
+print0(f"mfu_percent:      {steady_state_mfu:.2f}")
+print0(f"total_tokens_M:   {total_tokens / 1e6:.1f}")
+print0(f"num_steps:        {step}")
+print0(f"num_params_M:     {num_params / 1e6:.1f}")
+print0(f"depth:            {DEPTH}")
+
+if IS_DISTRIBUTED:
+    dist.destroy_process_group()

--- a/train.py
+++ b/train.py
@@ -26,8 +26,8 @@ WORLD_SIZE = int(os.environ.get("WORLD_SIZE", 1))
 IS_DISTRIBUTED = WORLD_SIZE > 1
 
 if IS_DISTRIBUTED:
-    dist.init_process_group(backend="nccl")
     torch.cuda.set_device(LOCAL_RANK)
+    dist.init_process_group(backend="nccl")
 
 from kernels import get_kernel
 
@@ -49,11 +49,12 @@ if IS_DISTRIBUTED:
         all_files = _original_list_parquet_files()
         val_path = os.path.join(prepare.DATA_DIR, prepare.VAL_FILENAME)
         train_files = [f for f in all_files if f != val_path]
-        assert len(train_files) >= WORLD_SIZE, (
-            f"Need at least {WORLD_SIZE} training shards for {WORLD_SIZE} GPUs, "
-            f"but only {len(train_files)} found. Download more shards with: "
-            f"uv run prepare.py --num-shards {WORLD_SIZE + 1}"
-        )
+        if len(train_files) < WORLD_SIZE:
+            raise RuntimeError(
+                f"Need at least {WORLD_SIZE} training shards for {WORLD_SIZE} GPUs, "
+                f"but only {len(train_files)} found. Download more shards with: "
+                f"uv run prepare.py --num-shards {WORLD_SIZE + 1}"
+            )
         rank_files = train_files[RANK::WORLD_SIZE]
         if os.path.exists(val_path):
             rank_files.append(val_path)
@@ -733,9 +734,9 @@ while True:
     # All-reduce gradients across ranks (must happen before optimizer step so
     # Muon's Newton-Schulz orthogonalization sees identical averaged gradients)
     if IS_DISTRIBUTED:
-        for p in model.parameters():
-            if p.grad is not None:
-                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+        grads = [p.grad for p in model.parameters() if p.grad is not None]
+        if grads:
+            dist.all_reduce_coalesced(grads, op=dist.ReduceOp.AVG)
 
     # Progress and schedules
     progress = min(total_training_time / TIME_BUDGET, 1.0)


### PR DESCRIPTION
## Summary

Fork of [karpathy/autoresearch](https://github.com/karpathy/autoresearch) renamed to **skylab**, extended with remote GPU execution and multi-GPU distributed training.

- **Remote execution**: `remote_run.sh` syncs code to a remote GPU machine via SSH, runs training, streams results back. Drop-in replacement for `uv run train.py`. Includes `Dockerfile` for reproducible CUDA 12.8 environments.
- **Multi-GPU distributed training**: DDP with manual gradient all-reduce in `train.py`. Launches via `torchrun --nproc_per_node=N train.py`. Fully backward-compatible with single-GPU.
- **Security hardening**: Proper quoting in shell scripts, TOML path validation, pinned uv version, coalesced gradient sync.
- **Project rename**: autoresearch → skylab (repo, project name, cache paths, branch naming).

## Changed files
| File | Change |
|------|--------|
| `train.py` | Distributed training: init, data sharding, gradient all-reduce, rank-0 logging/eval |
| `prepare.py` | Cache path `~/.cache/autoresearch` → `~/.cache/skylab` |
| `program.md` | Updated for remote/distributed launch commands, skylab branding |
| `README.md` | Streamlined, focused on remote cluster workflow |
| `.gitignore` | Added `remote.toml`, `.remote_state`, `run.log` |
| `pyproject.toml` | Project name → skylab |

## New files
| File | Purpose |
|------|---------|
| `Dockerfile` | CUDA 12.8 + Python 3.10 + uv (pinned v0.7.12) |
| `remote_run.sh` | SSH-based remote execution with timeout, validation, multi-GPU |
| `remote.toml` | Config template (gitignored) |

## Test plan
- [ ] Verify `uv run train.py` works on single GPU (backward compat)
- [ ] Test `remote_run.sh --check` against a provisioned GPU instance
- [ ] Test `remote_run.sh > run.log 2>&1` end-to-end on remote H100
- [ ] Test `torchrun --nproc_per_node=2 train.py` on multi-GPU node
- [ ] Verify `val_bpb` output format unchanged
- [ ] Confirm data downloads to `~/.cache/skylab/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)