### PR TITLE
Rename autoresearch to skylab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG UV_VERSION=0.7.12
 RUN curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
 ENV PATH="/root/.local/bin:$PATH"
 
-WORKDIR /workspace/autoresearch
+WORKDIR /workspace/skylab
 
 # Copy dependency files first (layer caching — only re-install when deps change)
 COPY pyproject.toml uv.lock .python-version ./
@@ -28,4 +28,4 @@ RUN uv sync --frozen
 COPY prepare.py train.py ./
 
 # Data is mounted at runtime, not baked into the image.
-# Mount your data volume at /root/.cache/autoresearch/
+# Mount your data volume at /root/.cache/skylab/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# autoresearch
+# skylab
 
 ![teaser](progress.png)
 
 Autonomous LLM training research — give an AI agent a real training setup and let it experiment overnight. It modifies the code, trains for 5 minutes, checks if the result improved, keeps or discards, and repeats. You wake up to a log of experiments and a better model.
 
-Based on [@karpathy's autoresearch](https://github.com/karpathy/autoresearch), extended with remote GPU execution and multi-GPU distributed training support.
+Fork of [@karpathy's autoresearch](https://github.com/karpathy/autoresearch), extended with remote GPU execution and multi-GPU distributed training support.
 
 ## How it works
 

--- a/prepare.py
+++ b/prepare.py
@@ -1,12 +1,12 @@
 """
-One-time data preparation for autoresearch experiments.
+One-time data preparation for skylab experiments.
 Downloads data shards and trains a BPE tokenizer.
 
 Usage:
     python prepare.py                  # full prep (download + tokenizer)
     python prepare.py --num-shards 8   # download only 8 shards (for testing)
 
-Data and tokenizer are stored in ~/.cache/autoresearch/.
+Data and tokenizer are stored in ~/.cache/skylab/.
 """
 
 import os
@@ -27,19 +27,19 @@ import torch
 # Constants (fixed, do not modify)
 # ---------------------------------------------------------------------------
 
-MAX_SEQ_LEN = 2048       # context length
-TIME_BUDGET = 300        # training time budget in seconds (5 minutes)
+MAX_SEQ_LEN = 2048  # context length
+TIME_BUDGET = 300  # training time budget in seconds (5 minutes)
 EVAL_TOKENS = 40 * 524288  # number of tokens for val eval
 
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
 
-CACHE_DIR = os.path.join(os.path.expanduser("~"), ".cache", "autoresearch")
+CACHE_DIR = os.path.join(os.path.expanduser("~"), ".cache", "skylab")
 DATA_DIR = os.path.join(CACHE_DIR, "data")
 TOKENIZER_DIR = os.path.join(CACHE_DIR, "tokenizer")
 BASE_URL = "https://huggingface.co/datasets/karpathy/climbmix-400b-shuffle/resolve/main"
-MAX_SHARD = 6542 # the last datashard is shard_06542.parquet
+MAX_SHARD = 6542  # the last datashard is shard_06542.parquet
 VAL_SHARD = MAX_SHARD  # pinned validation shard (shard_06542)
 VAL_FILENAME = f"shard_{VAL_SHARD:05d}.parquet"
 VOCAB_SIZE = 8192
@@ -53,6 +53,7 @@ BOS_TOKEN = "<|reserved_0|>"
 # ---------------------------------------------------------------------------
 # Data download
 # ---------------------------------------------------------------------------
+
 
 def download_single_shard(index):
     """Download one parquet shard with retries. Returns True on success."""
@@ -84,7 +85,7 @@ def download_single_shard(index):
                     except OSError:
                         pass
             if attempt < max_attempts:
-                time.sleep(2 ** attempt)
+                time.sleep(2**attempt)
     return False
 
 
@@ -97,7 +98,11 @@ def download_data(num_shards, download_workers=8):
         ids.append(VAL_SHARD)
 
     # Count what's already downloaded
-    existing = sum(1 for i in ids if os.path.exists(os.path.join(DATA_DIR, f"shard_{i:05d}.parquet")))
+    existing = sum(
+        1
+        for i in ids
+        if os.path.exists(os.path.join(DATA_DIR, f"shard_{i:05d}.parquet"))
+    )
     if existing == len(ids):
         print(f"Data: all {len(ids)} shards already downloaded at {DATA_DIR}")
         return
@@ -112,13 +117,19 @@ def download_data(num_shards, download_workers=8):
     ok = sum(1 for r in results if r)
     print(f"Data: {ok}/{len(ids)} shards ready at {DATA_DIR}")
 
+
 # ---------------------------------------------------------------------------
 # Tokenizer training
 # ---------------------------------------------------------------------------
 
+
 def list_parquet_files():
     """Return sorted list of parquet file paths in the data directory."""
-    files = sorted(f for f in os.listdir(DATA_DIR) if f.endswith(".parquet") and not f.endswith(".tmp"))
+    files = sorted(
+        f
+        for f in os.listdir(DATA_DIR)
+        if f.endswith(".parquet") and not f.endswith(".tmp")
+    )
     return [os.path.join(DATA_DIR, f) for f in files]
 
 
@@ -151,7 +162,9 @@ def train_tokenizer():
 
     parquet_files = list_parquet_files()
     if len(parquet_files) < 2:
-        print("Tokenizer: need at least 2 data shards (1 train + 1 val). Download more data first.")
+        print(
+            "Tokenizer: need at least 2 data shards (1 train + 1 val). Download more data first."
+        )
         sys.exit(1)
 
     # --- Train with rustbpe ---
@@ -160,7 +173,9 @@ def train_tokenizer():
 
     tokenizer = rustbpe.Tokenizer()
     vocab_size_no_special = VOCAB_SIZE - len(SPECIAL_TOKENS)
-    tokenizer.train_from_iterator(text_iterator(), vocab_size_no_special, pattern=SPLIT_PATTERN)
+    tokenizer.train_from_iterator(
+        text_iterator(), vocab_size_no_special, pattern=SPLIT_PATTERN
+    )
 
     # Build tiktoken encoding from trained merges
     pattern = tokenizer.get_pattern()
@@ -202,9 +217,11 @@ def train_tokenizer():
     assert decoded == test, f"Tokenizer roundtrip failed: {test!r} -> {decoded!r}"
     print(f"Tokenizer: sanity check passed (vocab_size={enc.n_vocab})")
 
+
 # ---------------------------------------------------------------------------
 # Runtime utilities (imported by train.py)
 # ---------------------------------------------------------------------------
+
 
 class Tokenizer:
     """Minimal tokenizer wrapper. Training is handled above."""
@@ -227,7 +244,11 @@ class Tokenizer:
 
     def encode(self, text, prepend=None, num_threads=8):
         if prepend is not None:
-            prepend_id = prepend if isinstance(prepend, int) else self.enc.encode_single_token(prepend)
+            prepend_id = (
+                prepend
+                if isinstance(prepend, int)
+                else self.enc.encode_single_token(prepend)
+            )
         if isinstance(text, str):
             ids = self.enc.encode_ordinary(text)
             if prepend is not None:
@@ -267,9 +288,9 @@ def _document_batches(split, tokenizer_batch_size=128):
             pf = pq.ParquetFile(filepath)
             for rg_idx in range(pf.num_row_groups):
                 rg = pf.read_row_group(rg_idx)
-                batch = rg.column('text').to_pylist()
+                batch = rg.column("text").to_pylist()
                 for i in range(0, len(batch), tokenizer_batch_size):
-                    yield batch[i:i+tokenizer_batch_size], epoch
+                    yield batch[i : i + tokenizer_batch_size], epoch
         epoch += 1
 
 
@@ -297,10 +318,10 @@ def make_dataloader(tokenizer, B, T, split, buffer_size=1000):
     row_buffer = torch.empty((B, row_capacity), dtype=torch.long)
     cpu_buffer = torch.empty(2 * B * T, dtype=torch.long, pin_memory=True)
     gpu_buffer = torch.empty(2 * B * T, dtype=torch.long, device="cuda")
-    cpu_inputs = cpu_buffer[:B * T].view(B, T)
-    cpu_targets = cpu_buffer[B * T:].view(B, T)
-    inputs = gpu_buffer[:B * T].view(B, T)
-    targets = gpu_buffer[B * T:].view(B, T)
+    cpu_inputs = cpu_buffer[: B * T].view(B, T)
+    cpu_targets = cpu_buffer[B * T :].view(B, T)
+    inputs = gpu_buffer[: B * T].view(B, T)
+    targets = gpu_buffer[B * T :].view(B, T)
 
     while True:
         for row_idx in range(B):
@@ -322,13 +343,19 @@ def make_dataloader(tokenizer, B, T, split, buffer_size=1000):
 
                 if best_idx >= 0:
                     doc = doc_buffer.pop(best_idx)
-                    row_buffer[row_idx, pos:pos + len(doc)] = torch.tensor(doc, dtype=torch.long)
+                    row_buffer[row_idx, pos : pos + len(doc)] = torch.tensor(
+                        doc, dtype=torch.long
+                    )
                     pos += len(doc)
                 else:
                     # No doc fits — crop shortest to fill remaining
-                    shortest_idx = min(range(len(doc_buffer)), key=lambda i: len(doc_buffer[i]))
+                    shortest_idx = min(
+                        range(len(doc_buffer)), key=lambda i: len(doc_buffer[i])
+                    )
                     doc = doc_buffer.pop(shortest_idx)
-                    row_buffer[row_idx, pos:pos + remaining] = torch.tensor(doc[:remaining], dtype=torch.long)
+                    row_buffer[row_idx, pos : pos + remaining] = torch.tensor(
+                        doc[:remaining], dtype=torch.long
+                    )
                     pos += remaining
 
         cpu_inputs.copy_(row_buffer[:, :-1])
@@ -336,9 +363,11 @@ def make_dataloader(tokenizer, B, T, split, buffer_size=1000):
         gpu_buffer.copy_(cpu_buffer, non_blocking=True)
         yield inputs, targets, epoch
 
+
 # ---------------------------------------------------------------------------
 # Evaluation (DO NOT CHANGE — this is the fixed metric)
 # ---------------------------------------------------------------------------
+
 
 @torch.no_grad()
 def evaluate_bpb(model, tokenizer, batch_size):
@@ -356,7 +385,7 @@ def evaluate_bpb(model, tokenizer, batch_size):
     total_bytes = 0
     for _ in range(steps):
         x, y, _ = next(val_loader)
-        loss_flat = model(x, y, reduction='none').view(-1)
+        loss_flat = model(x, y, reduction="none").view(-1)
         y_flat = y.view(-1)
         nbytes = token_bytes[y_flat]
         mask = nbytes > 0
@@ -364,14 +393,27 @@ def evaluate_bpb(model, tokenizer, batch_size):
         total_bytes += nbytes.sum().item()
     return total_nats / (math.log(2) * total_bytes)
 
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Prepare data and tokenizer for autoresearch")
-    parser.add_argument("--num-shards", type=int, default=10, help="Number of training shards to download (-1 = all). Val shard is always pinned.")
-    parser.add_argument("--download-workers", type=int, default=8, help="Number of parallel download workers")
+    parser = argparse.ArgumentParser(
+        description="Prepare data and tokenizer for skylab"
+    )
+    parser.add_argument(
+        "--num-shards",
+        type=int,
+        default=10,
+        help="Number of training shards to download (-1 = all). Val shard is always pinned.",
+    )
+    parser.add_argument(
+        "--download-workers",
+        type=int,
+        default=8,
+        help="Number of parallel download workers",
+    )
     args = parser.parse_args()
 
     num_shards = MAX_SHARD if args.num_shards == -1 else args.num_shards

--- a/program.md
+++ b/program.md
@@ -1,4 +1,4 @@
-# autoresearch
+# skylab
 
 This is an experiment to have the LLM do its own research.
 
@@ -6,13 +6,13 @@ This is an experiment to have the LLM do its own research.
 
 To set up a new experiment, work with the user to:
 
-1. **Agree on a run tag**: propose a tag based on today's date (e.g. `mar5`). The branch `autoresearch/<tag>` must not already exist — this is a fresh run.
-2. **Create the branch**: `git checkout -b autoresearch/<tag>` from current master.
+1. **Agree on a run tag**: propose a tag based on today's date (e.g. `mar5`). The branch `skylab/<tag>` must not already exist — this is a fresh run.
+2. **Create the branch**: `git checkout -b skylab/<tag>` from current master.
 3. **Read the in-scope files**: The repo is small. Read these files for full context:
    - `README.md` — repository context.
    - `prepare.py` — fixed constants, data prep, tokenizer, dataloader, evaluation. Do not modify.
    - `train.py` — the file you modify. Model architecture, optimizer, training loop.
-4. **Verify data exists**: Check that `~/.cache/autoresearch/` contains data shards and a tokenizer. If not, tell the human to run `uv run prepare.py`.
+4. **Verify data exists**: Check that `~/.cache/skylab/` contains data shards and a tokenizer. If not, tell the human to run `uv run prepare.py`.
 5. **Initialize results.tsv**: Create `results.tsv` with just the header row. The baseline will be recorded after the first run.
 6. **Confirm and go**: Confirm setup looks good.
 
@@ -98,7 +98,7 @@ d4e5f6g	0.000000	0.0	crash	double model width (OOM)
 
 ## The experiment loop
 
-The experiment runs on a dedicated branch (e.g. `autoresearch/mar5` or `autoresearch/mar5-gpu0`).
+The experiment runs on a dedicated branch (e.g. `skylab/mar5` or `skylab/mar5-gpu0`).
 
 LOOP FOREVER:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "autoresearch"
+name = "skylab"
 version = "0.1.0"
 description = "Autonomous pretraining research swarm"
 readme = "README.md"

--- a/remote_run.sh
+++ b/remote_run.sh
@@ -43,8 +43,8 @@ validate_path() {
 HOST=$(get_config "host")
 REMOTE_USER=$(get_config "user" "ubuntu")
 KEY_PATH=$(get_config "key_path" "~/.ssh/id_rsa")
-WORKSPACE=$(get_config "workspace" "/workspace/autoresearch")
-CACHE_DIR=$(get_config "cache_dir" "~/.cache/autoresearch")
+WORKSPACE=$(get_config "workspace" "/workspace/skylab")
+CACHE_DIR=$(get_config "cache_dir" "~/.cache/skylab")
 NUM_GPUS=$(get_config "num_gpus" "1")
 USE_CONTAINER=$(get_config "use_container" "false")
 IMAGE=$(get_config "image")
@@ -167,8 +167,8 @@ run_training() {
     local remote_cmd
     if [ "$USE_CONTAINER" = "true" ] && [ -n "$IMAGE" ]; then
         remote_cmd="timeout ${RUN_TIMEOUT} docker run --rm --gpus all \
-            -v '${CACHE_DIR}':/root/.cache/autoresearch \
-            -v '${WORKSPACE}':/workspace/autoresearch \
+            -v '${CACHE_DIR}':/root/.cache/skylab \
+            -v '${WORKSPACE}':/workspace/skylab \
             '${IMAGE}' ${train_cmd}"
     else
         remote_cmd="cd '${WORKSPACE}' && timeout ${RUN_TIMEOUT} ${train_cmd}"

--- a/uv.lock
+++ b/uv.lock
@@ -42,7 +42,7 @@ wheels = [
 ]
 
 [[package]]
-name = "autoresearch"
+name = "skylab"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [


### PR DESCRIPTION
## Summary
- Rename all `autoresearch` references to `skylab` to match the repo name
- Updates README title, package name (`pyproject.toml`, `uv.lock`), cache directories (`~/.cache/skylab`), Docker paths, remote execution defaults, branch prefixes in agent instructions (`program.md`)
- Only remaining `autoresearch` reference is the attribution link to Karpathy's upstream repo

## Test plan
- [x] Verify `uv sync` still resolves correctly with the new package name
- [x] Confirm `uv run prepare.py` uses `~/.cache/skylab/` as the cache directory
- [x] Check that `remote_run.sh` defaults point to `/workspace/skylab`

🤖 Generated with [Claude Code](https://claude.com/claude-code)